### PR TITLE
Update versions of Actions we use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,10 +63,12 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+
     - name: Run Python Lint
       run: |
         echo "::debug::Running Python Lint for ${INPUTS_LINTER} on ${INPUTS_TARGET} with Python ${INPUTS_PYTHON_VERSION}"
@@ -202,14 +204,16 @@ runs:
         INPUTS_TYPESHED_VERSION: ${{ inputs.typeshed-version }}
         GH_TOKEN: ${{ github.token }}
       shell: bash
+
     - name: Upload SARIF
       if: ${{ hashFiles(inputs.output) != '' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ inputs.output }}
+
     - name: Upload SARIF as debug artefact
       if: ${{ always() && runner.debug == '1' && hashFiles(inputs.output) != '' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.output }}
         path: ${{ inputs.output }}


### PR DESCRIPTION
This pull request updates the `action.yml` file, upgrading the versions of GitHub Actions used.

Updates to GitHub Actions versions:

* Updated `actions/setup-python` from version 4 to version 5
* Updated `actions/upload-artifact` from version 3 to version 4