### PR TITLE
Potential fix for code scanning alert no. 553: Log Injection

### DIFF
--- a/python_lint.py
+++ b/python_lint.py
@@ -770,7 +770,7 @@ def main() -> None:
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
     if any({linter not in LINTERS for linter in args.linter}):
-        sanitized_linter = [linter.replace('\n', '').replace('\r', '') for linter in args.linter]
+        sanitized_linter = [re.sub(r'[\x00-\x1F]', '', linter) for linter in args.linter]
         LOG.error("Invalid linter choice: %s", ', '.join(sanitized_linter))
         sys.exit(1)
 

--- a/python_lint.py
+++ b/python_lint.py
@@ -770,7 +770,8 @@ def main() -> None:
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
     if any({linter not in LINTERS for linter in args.linter}):
-        LOG.error("Invalid linter choice: %s", args.linter)
+        sanitized_linter = [linter.replace('\n', '').replace('\r', '') for linter in args.linter]
+        LOG.error("Invalid linter choice: %s", sanitized_linter)
         sys.exit(1)
 
     sarif_runs: List[dict] = []

--- a/python_lint.py
+++ b/python_lint.py
@@ -771,7 +771,7 @@ def main() -> None:
 
     if any({linter not in LINTERS for linter in args.linter}):
         sanitized_linter = [linter.replace('\n', '').replace('\r', '') for linter in args.linter]
-        LOG.error("Invalid linter choice: %s", sanitized_linter)
+        LOG.error("Invalid linter choice: %s", ', '.join(sanitized_linter))
         sys.exit(1)
 
     sarif_runs: List[dict] = []


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/python-lint-code-scanning-action/security/code-scanning/553](https://github.com/advanced-security/python-lint-code-scanning-action/security/code-scanning/553)

To fix the issue, we need to sanitize the user-provided input (`args.linter`) before logging it. Specifically:
1. Remove any newline characters (`\n` and `\r`) from the input to prevent log injection.
2. Optionally, escape or replace other potentially harmful characters to ensure the log entry is safe and unambiguous.

The best approach is to use Python's `str.replace()` method to remove newline characters from the `args.linter` value before including it in the log message. This ensures that the log entry remains safe while preserving the original functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
