### PR TITLE
Potential fix for code scanning alert no. 556: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,6 @@ on:
     - cron: '22 3 * * 2'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     runs-on: ${{ matrix.os }}
@@ -21,6 +18,8 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest] # doesn't yet work on Windows
       fail-fast: false
+    permissions:
+      security-events: write
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
     - cron: '22 3 * * 2'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/python-lint-code-scanning-action/security/code-scanning/556](https://github.com/advanced-security/python-lint-code-scanning-action/security/code-scanning/556)

To fix the issue, add a `permissions` block at the root level of the workflow file. Since this is a linting workflow, it only needs read access to the repository contents. The `permissions` block should be set to `contents: read`. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
